### PR TITLE
Compile fix for gcc 4.8.3

### DIFF
--- a/src/server/ua_subscription.h
+++ b/src/server/ua_subscription.h
@@ -64,7 +64,7 @@ typedef struct UA_unpublishedNotification {
     UA_NotificationMessage notification;
 } UA_unpublishedNotification;
 
-struct UA_Subscription {
+typedef struct UA_Subscription {
     LIST_ENTRY(UA_Subscription) listEntry;
     UA_BoundedUInt32 lifeTime;
     UA_BoundedUInt32 keepAliveCount;
@@ -80,7 +80,7 @@ struct UA_Subscription {
     LIST_HEAD(UA_ListOfUnpublishedNotifications, UA_unpublishedNotification) unpublishedNotifications;
     size_t unpublishedNotificationsSize;
     LIST_HEAD(UA_ListOfUAMonitoredItems, UA_MonitoredItem) MonitoredItems;
-};
+} UA_Subscription;
 
 UA_Subscription *UA_Subscription_new(UA_UInt32 subscriptionID);
 void UA_Subscription_deleteMembers(UA_Subscription *subscription, UA_Server *server);


### PR DESCRIPTION
In the type defintion of UA_Subscription the "typedef" was missing
