### PR TITLE
Compile fix for gcc 4.8.3

### DIFF
--- a/src/ua_session.h
+++ b/src/ua_session.h
@@ -17,7 +17,6 @@ struct ContinuationPointEntry {
 };
 
 struct UA_Subscription;
-typedef struct UA_Subscription UA_Subscription;
 
 struct UA_Session {
     UA_ApplicationDescription clientDescription;


### PR DESCRIPTION
Removed compile breakting redefinition of UA_Subscription
